### PR TITLE
Fix hosts only pulling the last worker

### DIFF
--- a/cmd/rffmpeg-go/ffmpeg.go
+++ b/cmd/rffmpeg-go/ffmpeg.go
@@ -169,7 +169,8 @@ func getHostMappings(proc *processor.Processor, hosts []processor.Host) ([]HostM
 	hostMappingC := make(chan HostMapping, len(hosts))
 	var worker conc.WaitGroup
 
-	for _, host := range hosts {
+	for _, h := range hosts {
+		host := h
 		worker.Go(func() {
 			hostMapping, err := getHostMapping(proc, host)
 			if err != nil {


### PR DESCRIPTION
This fixes #18. The for loop was iterating over the hosts and host always ends up being the last value by the time it is used for the first call of worker.Go causing the last-added worker to be reviewed each time .instead of the other workers,