### PR TITLE
Fix fallback support

### DIFF
--- a/cmd/rffmpeg-go/ffmpeg.go
+++ b/cmd/rffmpeg-go/ffmpeg.go
@@ -220,13 +220,13 @@ func getTargetHost(config Config, proc *processor.Processor) (processor.Host, er
 			continue
 		}
 
-		if hostMapping.Hostname == "localhost" || hostMapping.Hostname == "127.0.0.1" {
+		if hostMapping.Hostname != "localhost" && hostMapping.Hostname != "127.0.0.1" {
 			log.Debug().
 				Msg("Running SSH test")
 
 			testSshCommand := generateSshCommand(config, hostMapping.Hostname)
 			testSshCommand = removeFromSlice(testSshCommand, "-q")
-			testFfmpegCommand := config.Commands.Ffmpeg + "-version"
+			testFfmpegCommand := config.Commands.Ffmpeg + " -version"
 			testFullCommand := append(testSshCommand, testFfmpegCommand)
 			testCommand := runCommand(testFullCommand, os.Stdin, os.Stdout, os.Stderr)
 			err = testCommand.Run()


### PR DESCRIPTION
Fallback was not working. After reviewing the code, I found that the host test only happened when the host was localhost.

I also found the test command was failing because there was no space between the ffmpeg binary and -version.

Here is a test image if you would like to use it for testing ghcr.io/seang96/jellyfin-rffmpeg-intro-skipper:latest